### PR TITLE
Don't import models at module import time

### DIFF
--- a/provider/oauth2/__init__.py
+++ b/provider/oauth2/__init__.py
@@ -1,7 +1,1 @@
-import backends
-import forms
-import models
-import urls
-import views
-
 default_app_config = 'provider.oauth2.apps.Oauth2'


### PR DESCRIPTION
Django 1.9 doesn't allow loading models before their apps anymore, i.e. at module import time.

Fixes these exceptions:

```
django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
```
