### PR TITLE
Stop using `django.conf.urls.patterns`

### DIFF
--- a/provider/oauth2/urls.py
+++ b/provider/oauth2/urls.py
@@ -35,10 +35,10 @@ that are meant for client (as defined in :rfc:`1`) interaction.
 
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.csrf import csrf_exempt
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url
 from provider.oauth2 import views
 
-urlpatterns = patterns('',
+urlpatterns = [
     url('^authorize/?$',
         login_required(views.CaptureView.as_view()),
         name='capture'),
@@ -51,4 +51,4 @@ urlpatterns = patterns('',
     url('^access_token/?$',
         csrf_exempt(views.AccessTokenView.as_view()),
         name='access_token'),
-)
+]


### PR DESCRIPTION
As per the django 1.8 release notes:
https://docs.djangoproject.com/en/1.8/releases/1.8/#django-conf-urls-patterns

To quiet these DeprecationWarnings:

> py.warnings WARNING: .../.venv/src/django-oauth2/provider/oauth2/urls.py:53: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
>   name='access_token'),
