### PR TITLE
request.REQUEST has been removed in django 1.9

### DIFF
--- a/provider/oauth2/backends.py
+++ b/provider/oauth2/backends.py
@@ -53,7 +53,9 @@ class RequestParamsClientBackend(object):
         if request is None:
             return None
 
-        form = ClientAuthForm(request.REQUEST)
+        request_data = request.GET.copy()
+        request_data.update(request.POST)
+        form = ClientAuthForm(request_data)
 
         if form.is_valid():
             return form.cleaned_data.get('client')
@@ -74,7 +76,9 @@ class PublicPasswordBackend(object):
         if request is None:
             return None
 
-        form = PublicPasswordGrantForm(request.REQUEST)
+        request_data = request.GET.copy()
+        request_data.update(request.POST)
+        form = PublicPasswordGrantForm(request_data)
 
         if form.is_valid():
             return form.cleaned_data.get('client')

--- a/provider/oauth2/tests.py
+++ b/provider/oauth2/tests.py
@@ -1,7 +1,6 @@
 import json
 import urlparse
 import datetime
-from unittest import SkipTest
 from django.http import QueryDict
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -438,8 +437,8 @@ class AuthBackendTest(BaseOAuth2TestCase):
     def test_request_params_client_backend(self):
         request = type('Request', (object,), {'REQUEST': {}})()
 
-        request.REQUEST['client_id'] = self.get_client().client_id
-        request.REQUEST['client_secret'] = self.get_client().client_secret
+        request.GET['client_id'] = self.get_client().client_id
+        request.GET['client_secret'] = self.get_client().client_secret
 
         self.assertEqual(RequestParamsClientBackend().authenticate(request).id,
                          2, "Didn't return the right client.'")

--- a/provider/views.py
+++ b/provider/views.py
@@ -511,8 +511,9 @@ class AccessTokenViewBase(AuthUtilMixin, TemplateView):
         Handle ``grant_type=authorization_code`` requests as defined in
         :rfc:`4.1.3`.
         """
-        grant = self.get_authorization_code_grant(request, request.REQUEST,
-                client)
+        request_data = request.GET.copy()
+        request_data.update(request.POST)
+        grant = self.get_authorization_code_grant(request, request_data, client)
         at = self.create_access_token(request, grant.user,
                                       list(grant.scope.all()), client)
         rt = self.create_refresh_token(request, grant.user,
@@ -590,13 +591,15 @@ class AccessTokenViewBase(AuthUtilMixin, TemplateView):
                 'error': 'invalid_request',
                 'error_description': _("A secure connection is required.")})
 
-        if not 'grant_type' in request.REQUEST:
+        request_data = request.GET.copy()
+        request_data.update(request.POST)
+        if not 'grant_type' in request_data:
             return self.error_response({
                 'error': 'invalid_request',
-                'error_description': _("No 'grant_type' included in the "
-                    "request.")})
+                'error_description': _("No 'grant_type' included in the request.")
+            })
 
-        grant_type = request.REQUEST['grant_type']
+        grant_type = request_data['grant_type']
 
         if grant_type not in self.grant_types:
             return self.error_response({'error': 'unsupported_grant_type'})


### PR DESCRIPTION
```
py.warnings WARNING: RemovedInDjango19Warning: `request.REQUEST` is deprecated,
use `request.GET` or `request.POST` instead.
```

As per https://docs.djangoproject.com/en/1.9/releases/1.9/#features-removed-in-1-9
